### PR TITLE
Bad link for ECMAScript 262 standard--it was missing a hyphen + typo fix.

### DIFF
--- a/class1/slides/07_homework.md
+++ b/class1/slides/07_homework.md
@@ -3,5 +3,5 @@
 
 * Read Chapters 3 & 4
 * test first exercises: learn_javascript 01 - 03
-* Extra Credit: Section 4 Overview, and Section 8 types (only 8.1-8.5) int he ECMAScript specification.
-* http://www.ecmainternational.org/publications/standards/ecma-262.htm
+* Extra Credit: Section 4 Overview, and Section 8 types (only 8.1-8.5) in the ECMAScript specification.
+* http://www.ecma-international.org/publications/standards/Ecma-262.htm


### PR DESCRIPTION
Bad link for ECMAScript 262 standard--it was missing a hyphen.  Also fixed a typo in 'Extra Credit' line too.
